### PR TITLE
[pdpix] Renaming API Prefix

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -11,7 +11,7 @@ mod bytesmut;
 
 use crate::{
     fail::Fail,
-    types::dmtr_sgarray_t,
+    types::demi_sgarray_t,
 };
 
 //==============================================================================
@@ -33,15 +33,15 @@ pub trait MemoryRuntime {
     /// Memory Buffer
     type Buf: Buffer;
 
-    /// Creates a [dmtr_sgarray_t] from a [Buffer].
-    fn into_sgarray(&self, buf: Self::Buf) -> Result<dmtr_sgarray_t, Fail>;
+    /// Creates a [demi_sgarray_t] from a [Buffer].
+    fn into_sgarray(&self, buf: Self::Buf) -> Result<demi_sgarray_t, Fail>;
 
-    /// Allocates a [dmtr_sgarray_t].
-    fn alloc_sgarray(&self, size: usize) -> Result<dmtr_sgarray_t, Fail>;
+    /// Allocates a [demi_sgarray_t].
+    fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail>;
 
-    /// Releases a [dmtr_sgarray_t].
-    fn free_sgarray(&self, sga: dmtr_sgarray_t) -> Result<(), Fail>;
+    /// Releases a [demi_sgarray_t].
+    fn free_sgarray(&self, sga: demi_sgarray_t) -> Result<(), Fail>;
 
-    /// Clones a [dmtr_sgarray_t] into a [Buffer].
-    fn clone_sgarray(&self, sga: &dmtr_sgarray_t) -> Result<Self::Buf, Fail>;
+    /// Clones a [demi_sgarray_t] into a [Buffer].
+    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<Self::Buf, Fail>;
 }

--- a/src/types/memory.rs
+++ b/src/types/memory.rs
@@ -17,7 +17,7 @@ use ::libc::{
 //==============================================================================
 
 /// Maximum Length for Scatter-Gather Arrays
-pub const DMTR_SGARRAY_MAXLEN: usize = 1;
+pub const DEMI_SGARRAY_MAXLEN: usize = 1;
 
 //==============================================================================
 // Structures
@@ -26,7 +26,7 @@ pub const DMTR_SGARRAY_MAXLEN: usize = 1;
 /// Scatter-Gather Array Segment
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct dmtr_sgaseg_t {
+pub struct demi_sgaseg_t {
     /// Underlying data.
     pub sgaseg_buf: *mut c_void,
     /// Length of underlying data.
@@ -36,9 +36,9 @@ pub struct dmtr_sgaseg_t {
 /// Scatter-Gather Array
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct dmtr_sgarray_t {
+pub struct demi_sgarray_t {
     pub sga_buf: *mut c_void,
     pub sga_numsegs: u32,
-    pub sga_segs: [dmtr_sgaseg_t; DMTR_SGARRAY_MAXLEN],
+    pub sga_segs: [demi_sgaseg_t; DEMI_SGARRAY_MAXLEN],
     pub sga_addr: sockaddr_in,
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,15 +11,15 @@ mod queue;
 
 pub use self::{
     memory::{
-        dmtr_sgarray_t,
-        dmtr_sgaseg_t,
-        DMTR_SGARRAY_MAXLEN,
+        demi_sgarray_t,
+        demi_sgaseg_t,
+        DEMI_SGARRAY_MAXLEN,
     },
     ops::{
-        dmtr_accept_result_t,
-        dmtr_opcode_t,
-        dmtr_qr_value_t,
-        dmtr_qresult_t,
+        demi_accept_result_t,
+        demi_opcode_t,
+        demi_qr_value_t,
+        demi_qresult_t,
     },
-    queue::dmtr_qtoken_t,
+    queue::demi_qtoken_t,
 };

--- a/src/types/ops.rs
+++ b/src/types/ops.rs
@@ -8,8 +8,8 @@
 //==============================================================================
 
 use crate::types::{
-    memory::dmtr_sgarray_t,
-    queue::dmtr_qtoken_t,
+    memory::demi_sgarray_t,
+    queue::demi_qtoken_t,
 };
 use ::libc::{
     c_int,
@@ -23,34 +23,34 @@ use ::libc::{
 /// Operation Code
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
-pub enum dmtr_opcode_t {
-    DMTR_OPC_INVALID = 0,
-    DMTR_OPC_PUSH,
-    DMTR_OPC_POP,
-    DMTR_OPC_ACCEPT,
-    DMTR_OPC_CONNECT,
-    DMTR_OPC_FAILED,
+pub enum demi_opcode_t {
+    DEMI_OPC_INVALID = 0,
+    DEMI_OPC_PUSH,
+    DEMI_OPC_POP,
+    DEMI_OPC_ACCEPT,
+    DEMI_OPC_CONNECT,
+    DEMI_OPC_FAILED,
 }
 
 /// Result for `accept()`
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct dmtr_accept_result_t {
+pub struct demi_accept_result_t {
     pub qd: c_int,
     pub addr: sockaddr_in,
 }
 
 #[repr(C)]
-pub union dmtr_qr_value_t {
-    pub sga: dmtr_sgarray_t,
-    pub ares: dmtr_accept_result_t,
+pub union demi_qr_value_t {
+    pub sga: demi_sgarray_t,
+    pub ares: demi_accept_result_t,
 }
 
 /// Result
 #[repr(C)]
-pub struct dmtr_qresult_t {
-    pub qr_opcode: dmtr_opcode_t,
+pub struct demi_qresult_t {
+    pub qr_opcode: demi_opcode_t,
     pub qr_qd: c_int,
-    pub qr_qt: dmtr_qtoken_t,
-    pub qr_value: dmtr_qr_value_t,
+    pub qr_qt: demi_qtoken_t,
+    pub qr_value: demi_qr_value_t,
 }

--- a/src/types/queue.rs
+++ b/src/types/queue.rs
@@ -8,4 +8,4 @@
 //==============================================================================
 
 /// Queue Token
-pub type dmtr_qtoken_t = u64;
+pub type demi_qtoken_t = u64;


### PR DESCRIPTION
Description
========

Thir PR partially fixes issue https://github.com/demikernel/demikernel/issues/27.

In summary, I changed the `dmtr` prefix used in the PDPIX to match the new one, `demi`