### PR TITLE
[memory] Dropping `MemoryRuntime` 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ extern crate derive_more;
 extern crate test;
 
 use self::{
-    memory::MemoryRuntime,
     network::NetworkRuntime,
     task::SchedulerRuntime,
 };
@@ -63,4 +62,4 @@ pub use dpdk_rs as libdpdk;
 //==============================================================================
 
 /// Demikernel Runtime
-pub trait Runtime: Clone + Unpin + SchedulerRuntime + NetworkRuntime + MemoryRuntime + 'static {}
+pub trait Runtime: Clone + Unpin + SchedulerRuntime + NetworkRuntime + 'static {}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -19,7 +19,6 @@ use crate::{
             MacAddress,
         },
     },
-    MemoryRuntime,
 };
 use ::arrayvec::ArrayVec;
 
@@ -48,7 +47,7 @@ pub trait PacketBuf {
 }
 
 /// Network Runtime
-pub trait NetworkRuntime: MemoryRuntime {
+pub trait NetworkRuntime {
     /// Transmits a single [PacketBuf].
     fn transmit(&self, pkt: impl PacketBuf);
 


### PR DESCRIPTION
Description
-------------

This commit partially fixes https://github.com/demikernel/inetstack/issues/180

Summary of Changes
------------------------
- Removed `MemoryRuntime` from trait bound list in `Runtime`.