### PR TITLE
[network] Move to std network types

### DIFF
--- a/src/network/config/arp.rs
+++ b/src/network/config/arp.rs
@@ -5,12 +5,10 @@
 // Imports
 //==============================================================================
 
-use crate::network::types::{
-    Ipv4Addr,
-    MacAddress,
-};
+use crate::network::types::MacAddress;
 use ::std::{
     collections::HashMap,
+    net::IpAddr,
     time::Duration,
 };
 
@@ -28,7 +26,7 @@ pub struct ArpConfig {
     /// Retry Count for ARP Requests
     retry_count: usize,
     /// Initial Values for ARP Cache
-    initial_values: HashMap<Ipv4Addr, MacAddress>,
+    initial_values: HashMap<IpAddr, MacAddress>,
     /// Disable ARP?
     disable_arp: bool,
 }
@@ -44,7 +42,7 @@ impl ArpConfig {
         cache_ttl: Option<Duration>,
         request_timeout: Option<Duration>,
         retry_count: Option<usize>,
-        initial_values: Option<HashMap<Ipv4Addr, MacAddress>>,
+        initial_values: Option<HashMap<IpAddr, MacAddress>>,
         disable_arp: Option<bool>,
     ) -> Self {
         let mut config: ArpConfig = Self::default();
@@ -84,7 +82,7 @@ impl ArpConfig {
     }
 
     /// Gets the initial values for the ARP Cache in the target [ArpConfig].
-    pub fn get_initial_values(&self) -> &HashMap<Ipv4Addr, MacAddress> {
+    pub fn get_initial_values(&self) -> &HashMap<IpAddr, MacAddress> {
         &self.initial_values
     }
 
@@ -109,7 +107,7 @@ impl ArpConfig {
     }
 
     /// Sets the initial values for the ARP Cache in the target [ArpConfig].
-    fn set_initial_values(&mut self, initial_values: HashMap<Ipv4Addr, MacAddress>) {
+    fn set_initial_values(&mut self, initial_values: HashMap<IpAddr, MacAddress>) {
         self.initial_values = initial_values;
     }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,13 +14,11 @@ use crate::{
             UdpConfig,
         },
         consts::RECEIVE_BATCH_SIZE,
-        types::{
-            Ipv4Addr,
-            MacAddress,
-        },
+        types::MacAddress,
     },
 };
 use ::arrayvec::ArrayVec;
+use ::std::net::IpAddr;
 
 //==============================================================================
 // Exports
@@ -57,8 +55,8 @@ pub trait NetworkRuntime {
     /// Returns the [MacAddress] of the local endpoint.
     fn local_link_addr(&self) -> MacAddress;
 
-    /// Returns the [Ipv4Addr] of the local endpoint.
-    fn local_ipv4_addr(&self) -> Ipv4Addr;
+    /// Returns the [IpAddr] of the local endpoint.
+    fn local_ip_addr(&self) -> IpAddr;
 
     /// Returns the ARP Configuration Descriptor of the target [NetworkRuntime].
     fn arp_options(&self) -> ArpConfig;

--- a/src/network/types/ipv4.rs
+++ b/src/network/types/ipv4.rs
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-//==============================================================================
-// Exports
-//==============================================================================
-
-/// IPv4 Address
-pub use std::net::Ipv4Addr;

--- a/src/network/types/mod.rs
+++ b/src/network/types/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-mod ipv4;
 mod macaddr;
 mod portnum;
 
@@ -10,7 +9,6 @@ mod portnum;
 //==============================================================================
 
 pub use self::{
-    ipv4::Ipv4Addr,
     macaddr::MacAddress,
     portnum::Port16,
 };

--- a/src/queue/qresult.rs
+++ b/src/queue/qresult.rs
@@ -5,12 +5,11 @@
 // Imports
 //==============================================================================
 
+use ::std::net::IpAddr;
+
 use crate::{
     fail::Fail,
-    network::types::{
-        Ipv4Addr,
-        Port16,
-    },
+    network::types::Port16,
     QDesc,
 };
 
@@ -24,6 +23,6 @@ pub enum QResult {
     Accept(QDesc),
     Push,
     PushTo,
-    Pop(Option<(Ipv4Addr, Port16)>, Vec<u8>),
+    Pop(Option<(IpAddr, Port16)>, Vec<u8>),
     Failed(Fail),
 }


### PR DESCRIPTION
Partially addresses this issue: https://github.com/demikernel/inetstack/issues/124

This is a part of a multi-part series of PRs. This series aims to move from custom types that support network-related data structures to standard library types in Rust. Multiple other PRs will follow targetting similar changes to other libraries (e.g. inetstack, demikernel).

