### PR TITLE
[scheduler] Dropping `NetworkRuntime`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@ extern crate derive_more;
 
 extern crate test;
 
-use self::network::NetworkRuntime;
-
 //==============================================================================
 // Exports
 //==============================================================================
@@ -58,4 +56,4 @@ pub use dpdk_rs as libdpdk;
 //==============================================================================
 
 /// Demikernel Runtime
-pub trait Runtime: Clone + Unpin + NetworkRuntime + 'static {}
+pub trait Runtime: Clone + Unpin + 'static {}

--- a/src/network/config/arp.rs
+++ b/src/network/config/arp.rs
@@ -5,10 +5,12 @@
 // Imports
 //==============================================================================
 
-use crate::network::types::MacAddress;
+use crate::network::types::{
+    Ipv4Addr,
+    MacAddress,
+};
 use ::std::{
     collections::HashMap,
-    net::IpAddr,
     time::Duration,
 };
 
@@ -26,7 +28,7 @@ pub struct ArpConfig {
     /// Retry Count for ARP Requests
     retry_count: usize,
     /// Initial Values for ARP Cache
-    initial_values: HashMap<IpAddr, MacAddress>,
+    initial_values: HashMap<Ipv4Addr, MacAddress>,
     /// Disable ARP?
     disable_arp: bool,
 }
@@ -42,7 +44,7 @@ impl ArpConfig {
         cache_ttl: Option<Duration>,
         request_timeout: Option<Duration>,
         retry_count: Option<usize>,
-        initial_values: Option<HashMap<IpAddr, MacAddress>>,
+        initial_values: Option<HashMap<Ipv4Addr, MacAddress>>,
         disable_arp: Option<bool>,
     ) -> Self {
         let mut config: ArpConfig = Self::default();
@@ -82,7 +84,7 @@ impl ArpConfig {
     }
 
     /// Gets the initial values for the ARP Cache in the target [ArpConfig].
-    pub fn get_initial_values(&self) -> &HashMap<IpAddr, MacAddress> {
+    pub fn get_initial_values(&self) -> &HashMap<Ipv4Addr, MacAddress> {
         &self.initial_values
     }
 
@@ -107,7 +109,7 @@ impl ArpConfig {
     }
 
     /// Sets the initial values for the ARP Cache in the target [ArpConfig].
-    fn set_initial_values(&mut self, initial_values: HashMap<IpAddr, MacAddress>) {
+    fn set_initial_values(&mut self, initial_values: HashMap<Ipv4Addr, MacAddress>) {
         self.initial_values = initial_values;
     }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -7,18 +7,7 @@
 
 use crate::{
     memory::Buffer,
-    network::{
-        config::{
-            ArpConfig,
-            TcpConfig,
-            UdpConfig,
-        },
-        consts::RECEIVE_BATCH_SIZE,
-        types::{
-            Ipv4Addr,
-            MacAddress,
-        },
-    },
+    network::consts::RECEIVE_BATCH_SIZE,
 };
 use ::arrayvec::ArrayVec;
 
@@ -43,29 +32,14 @@ pub trait PacketBuf {
     /// Returns the body size of the target [PacketBuf].
     fn body_size(&self) -> usize;
     /// Consumes and returns the body of the target [PacketBuf].
-    fn take_body(self) -> Option<Buffer>;
+    fn take_body(&self) -> Option<Buffer>;
 }
 
 /// Network Runtime
 pub trait NetworkRuntime {
     /// Transmits a single [PacketBuf].
-    fn transmit(&self, pkt: impl PacketBuf);
+    fn transmit(&self, pkt: Box<dyn PacketBuf>);
 
     /// Receives a batch of [PacketBuf].
     fn receive(&self) -> ArrayVec<Buffer, RECEIVE_BATCH_SIZE>;
-
-    /// Returns the [MacAddress] of the local endpoint.
-    fn local_link_addr(&self) -> MacAddress;
-
-    /// Returns the [Ipv4Addr] of the local endpoint.
-    fn local_ipv4_addr(&self) -> Ipv4Addr;
-
-    /// Returns the ARP Configuration Descriptor of the target [NetworkRuntime].
-    fn arp_options(&self) -> ArpConfig;
-
-    /// Returns the TCP Configuration Descriptor of the target [NetworkRuntime].
-    fn tcp_options(&self) -> TcpConfig;
-
-    /// Returns the UDP Configuration Descriptor of the target [NetworkRuntime].
-    fn udp_options(&self) -> UdpConfig;
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -14,11 +14,13 @@ use crate::{
             UdpConfig,
         },
         consts::RECEIVE_BATCH_SIZE,
-        types::MacAddress,
+        types::{
+            Ipv4Addr,
+            MacAddress,
+        },
     },
 };
 use ::arrayvec::ArrayVec;
-use ::std::net::IpAddr;
 
 //==============================================================================
 // Exports
@@ -55,8 +57,8 @@ pub trait NetworkRuntime {
     /// Returns the [MacAddress] of the local endpoint.
     fn local_link_addr(&self) -> MacAddress;
 
-    /// Returns the [IpAddr] of the local endpoint.
-    fn local_ip_addr(&self) -> IpAddr;
+    /// Returns the [Ipv4Addr] of the local endpoint.
+    fn local_ipv4_addr(&self) -> Ipv4Addr;
 
     /// Returns the ARP Configuration Descriptor of the target [NetworkRuntime].
     fn arp_options(&self) -> ArpConfig;

--- a/src/network/types/ipv4.rs
+++ b/src/network/types/ipv4.rs
@@ -1,16 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-mod ipv4;
-mod macaddr;
-mod portnum;
-
 //==============================================================================
 // Exports
 //==============================================================================
 
-pub use self::{
-    ipv4::Ipv4Addr,
-    macaddr::MacAddress,
-    portnum::Port16,
-};
+/// IPv4 Address
+pub use std::net::Ipv4Addr;

--- a/src/queue/qresult.rs
+++ b/src/queue/qresult.rs
@@ -5,11 +5,12 @@
 // Imports
 //==============================================================================
 
-use ::std::net::IpAddr;
-
 use crate::{
     fail::Fail,
-    network::types::Port16,
+    network::types::{
+        Ipv4Addr,
+        Port16,
+    },
     QDesc,
 };
 
@@ -23,6 +24,6 @@ pub enum QResult {
     Accept(QDesc),
     Push,
     PushTo,
-    Pop(Option<(IpAddr, Port16)>, Vec<u8>),
+    Pop(Option<(Ipv4Addr, Port16)>, Vec<u8>),
     Failed(Fail),
 }


### PR DESCRIPTION
Description
-------------

This is a partial fix for https://github.com/demikernel/inetstack/issues/180

Summary of Changes
------------------------
- Removed `NetworkRuntime` from trait bound list in `Runtime`.