### PR TITLE
[types] Rely on `sockaddr` in Demikernel Types

### DIFF
--- a/src/types/memory.rs
+++ b/src/types/memory.rs
@@ -9,7 +9,7 @@
 
 use ::libc::{
     c_void,
-    sockaddr_in,
+    sockaddr,
 };
 
 //==============================================================================
@@ -40,5 +40,5 @@ pub struct demi_sgarray_t {
     pub sga_buf: *mut c_void,
     pub sga_numsegs: u32,
     pub sga_segs: [demi_sgaseg_t; DEMI_SGARRAY_MAXLEN],
-    pub sga_addr: sockaddr_in,
+    pub sga_addr: sockaddr,
 }

--- a/src/types/ops.rs
+++ b/src/types/ops.rs
@@ -13,7 +13,7 @@ use crate::types::{
 };
 use ::libc::{
     c_int,
-    sockaddr_in,
+    sockaddr,
 };
 
 //==============================================================================
@@ -37,7 +37,7 @@ pub enum demi_opcode_t {
 #[derive(Copy, Clone)]
 pub struct demi_accept_result_t {
     pub qd: c_int,
-    pub addr: sockaddr_in,
+    pub addr: sockaddr,
 }
 
 #[repr(C)]


### PR DESCRIPTION
Description
-------------

This PR fixes https://github.com/demikernel/runtime/issues/37.

Summary of Changes
-------------------------

- Changed type of `demi_sgarray_t::sga_addr` to `libc::sockaddr`
- Changed type of `demi_accept_result_t::addr` to `libc::sockaddr`

Additional Notes
--------------------

- Once this change is merged in, we should patch bindings for other languages (C and C#) in [demikernel/demikernel](https://github.com/demikernel/demikernel)